### PR TITLE
content: remove stability index

### DIFF
--- a/pages/assets/templates-libraries.md
+++ b/pages/assets/templates-libraries.md
@@ -1,7 +1,3 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
-
 # Templates & Libraries
 
 Templates and libraries help us to quickly acccess predefined font styles and colors and reuse certain components. Further it provides us with the canvas sizes we're targeting.

--- a/pages/charts/basic-charts.md
+++ b/pages/charts/basic-charts.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 Almost all basic charts for our online platform are created using our online chart toolbox Q. Only charts with details and annotations that are not possible in Q are be designed by hand and uploaded through Q's Infographic tool. The print template for basic charts can be downloaded via the [assets page](assets).
 

--- a/pages/charts/dots-arrows.md
+++ b/pages/charts/dots-arrows.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 All dot plots and arrow charts for online should be done using the Q.
 

--- a/pages/charts/dual-axis.md
+++ b/pages/charts/dual-axis.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 
 Dual-Axis-Charts werden gebraucht um zwei Zeitreihen gegenüber zu stellen. Sie teilen sich die Zeitachse, bilden aber auf der y-Achse verschiedene Werte ab.
 

--- a/pages/charts/elections.md
+++ b/pages/charts/elections.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 All basic graphics produced for elections should be done in Q. In the case that custom colors should be added to a Q graphic, please see the color assignments on the [color page](colors). Examples of exemptions from Q graphics include choropleth maps and arrow maps.
 

--- a/pages/charts/guidelines.md
+++ b/pages/charts/guidelines.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 #### TL;dr
 - [All graphics are based on raw data](https://nzzdev.github.io/Storytelling-Styleguide/#/charts-guidelines?a=no-data-no-chart)

--- a/pages/charts/isotype.md
+++ b/pages/charts/isotype.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 Isotype-charts are an alternative to barcharts. [Empirical reserach](http://steveharoz.com/research/isotype/) shows that under certain conditions, they lead to a better recall of the information presented.
 
 ## Symbols should represent data

--- a/pages/charts/scatter-slope.md
+++ b/pages/charts/scatter-slope.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 Scatterplots are a great way to show correlation between variables. Keep in mind that they are not intuitive for all audiences and can be overwhelmingly complex in appearance. We use labeling and annotation in the following ways to help provide guidance to our readers and a comfortable entry point into the graphic.
 
 

--- a/pages/intro.md
+++ b/pages/intro.md
@@ -8,26 +8,6 @@ This documentation is designed to collected and maintain the styles and visual l
 
 This documentation is first and foremost for our team. We are designers, developers, data journalists, video reporters and motion designers. All of us have different needs and should be able to navigate around the guidelines that are outlined in the following pages.
 
-### Component Stability Index
-
- In order to clearly indicate which components described in this documentation can be considered stable or unstable, we have introduced a «Stability Index». Each of the key components within the documentation can be matched to one of the three different stability levels described below.
-
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
-**DO NOT USE**: This concept is still under heavy construction and may be subject to profound change or completely removed.
-
-```html|span-1,no-source,plain
-<div class="stabilityIndex unstable">Unstable</div>
-```
-**USE WITH CAUTION**: The concept's functionality and styling are to be considered a «draft» and are not yet approved by all parties affected. There might still be some changes made in the near future.
-
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
-**IN USE**: Functionality and styling are complete and should not change unless serious issues are encountered. Stable concepts are approved by the team and can be  considered «ready-to-use».
-
-
 
 # Changelog
 

--- a/pages/maps/choropleth.md
+++ b/pages/maps/choropleth.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 ### Choroplethic Maps
 

--- a/pages/maps/guidelines.md
+++ b/pages/maps/guidelines.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex unstable">Unstable</div>
-```
+
 
 ## _Digital First_
 

--- a/pages/maps/pointer.md
+++ b/pages/maps/pointer.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 
 The templates for print maps can be found on the [assets page](assets). Color definitions for maps can be found on the [color page](https://nzzdev.github.io/Storytelling-Styleguide/#/colors?a=maps-colors)
 

--- a/pages/scrollytelling/3d-modell-scroller.md
+++ b/pages/scrollytelling/3d-modell-scroller.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 # So funktioniert's
 

--- a/pages/scrollytelling/animierte-uebergaenge.md
+++ b/pages/scrollytelling/animierte-uebergaenge.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 
 # So funktioniert's
 Durch das Scrollen wird entweder ein animierter Übergang gestartet oder die Animation selbst gesteuert. Die Animation ist dazu da den Übergang von einer zum nächsten Ansicht «flüssiger» zu machen. Im Idealfall unterstützt der animierte Übergang die Erklärung des Sachverhaltes.  

--- a/pages/scrollytelling/bildabfolge.md
+++ b/pages/scrollytelling/bildabfolge.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 
 # So funktioniert's
 Bild füllt den ganzen Hintergrund. Text scrollt darüber. Nachdem der Text durchgescrollt ist, wechselt das Bild und es kommt ein nächster Textabschnitt. 

--- a/pages/scrollytelling/einblenden-abspielen.md
+++ b/pages/scrollytelling/einblenden-abspielen.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 
 # So funktioniert's
 Durch das Scrollen, werden Element eingeblendet. Bei Videos oder GIF können diese auch durch den Scroll bzw. das Einblenden abgespielt. Anders als bei anderen Scrollytelling-Techniken, bleiben hier die Grafiken nicht stehen. 

--- a/pages/scrollytelling/einfuehrung.md
+++ b/pages/scrollytelling/einfuehrung.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 # Grundlagen
 Das Scrollen ist neben dem Klicken eine der wichtigsten Methoden um das World Wide Web zu navigieren. Mit diesen Interaktionen kann Information aufgerufen, angesteuert und verändert werden. Klicken wird oft verwendet um Information aufzurufen oder abzuschicken. Ein Klick ist für die Nutzer und Nutzerinnen immer eine Entschiedung. Das Scrollen hingegen rückt Abschnitte einer Webseite in das Ansichtsfenster – den Viewport – und dient so einer flüssigen Navigation von Informationen. Diese Art der kontinuierlichen Interaktion bietet für visuelles, web-basiertes Storytelling eine Reihe von Möglichkeiten.  

--- a/pages/scrollytelling/fortschrittsanzeige.md
+++ b/pages/scrollytelling/fortschrittsanzeige.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 
 # So funktioniert's
 Grafik bleibt stehen, meist oben oder links am Browserrand angeschlagen. Mit dem Scrollen verändert sich die Grafik, meist um einen zeitlichen oder räumlichen Verlauf zu zeigen. So dient das "Sticky Element" als Anzeige wo man sich in der Gesichte befindet (Orientierung) und was an dem Zeitpunkt geschehen ist (Inhalt).  

--- a/pages/scrollytelling/grafikabfolge.md
+++ b/pages/scrollytelling/grafikabfolge.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 
 # So funktioniert's
 Die Grafik bleibt im Viewport stehen, Text erscheint – entweder als Annotation oder als Textblock. Beim nächsten Scroll, wechselt die Grafik und der nächste Textblock / Annontation erscheint. Die neue Grafik kann mit oder ohne Überblendung anzeigt werden.

--- a/pages/scrollytelling/pan-zoom.md
+++ b/pages/scrollytelling/pan-zoom.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 
 # So funktioniert's
 Anders als beim Scrollover, bleibt hier die Grafik oder das Bild nicht stehen, sondern bewegt oder vergrössert sich durch das Scrollen. Diese Technik wird oft für Geschichte angewendet, die anhand einer Karte erzählt werden. Mit Scrollen wird durch die Karte navigiert. 

--- a/pages/scrollytelling/video-scroller.md
+++ b/pages/scrollytelling/video-scroller.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex experimental">Experimental</div>
-```
+
 
 # So funktioniert's
 Durch das Scrollen wird die Position im Video kontrolliert. Annotation/Hervorhebungen können direkt im Video enthalten sein. Geschichte kann zusätzlich mit Scrollover-Textblöcken vertieft werden. Das Video kann den ganzen Viewport füllen und beim Scrollen stehen bleiben oder aber mit der Pan-und-Zoom Technik kombiniert werden (siehe Beispiel von der New York Times zur Beirut Explosion). 

--- a/pages/style/colors-parties.md
+++ b/pages/style/colors-parties.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 # Farben für politische Parteien
 

--- a/pages/style/colors-scales.md
+++ b/pages/style/colors-scales.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 ## Sequenzielle und divergierende Skalen
 

--- a/pages/style/colors.md
+++ b/pages/style/colors.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 #### Wir verwenden für unterschiedliche Bedürfnisse unterschiedliche Farbpaletten
 

--- a/pages/style/layout.md
+++ b/pages/style/layout.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 > Print baselines are based off of the millimeter line height in the NZZ print paper. Templates for print can be downloaded via the [assets page](assets).
 

--- a/pages/style/principles.md
+++ b/pages/style/principles.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 # Visual Principles
 

--- a/pages/style/typography.md
+++ b/pages/style/typography.md
@@ -1,6 +1,4 @@
-```html|span-1,no-source,plain
-<div class="stabilityIndex stable">Stable</div>
-```
+
 
 Print und Online verwenden verschiedene Schriftfamilien, haben aber gemeinsam definierte Formatvorlagen, die zur Übersetzung von Online zu Print verwendet werden können.
 

--- a/static/theme.css
+++ b/static/theme.css
@@ -4,26 +4,3 @@
     border: none !important;
     background: none !important;
 }
-
-.stabilityIndex {
-    text-align:center;
-    padding:8px; 
-    width:100%; 
-    height:100%; 
-    font-family:"Roboto", sans-serif; 
-    font-weight:bold;
-    font-size:12px;
-    letter-spacing:2px;
-    text-transform:uppercase;
-    color: #101820;
-    border-radius:16px;
-}
-.experimental {
-    background:#FF5578;
-}
-.unstable {
-    background:#FFD54F;
-}
-.stable {
-    background:#50C8A4;
-}


### PR DESCRIPTION
I propose to remove the stability index for the following reasons:

- It adds another layer of process – for the index to work, we
  would have to update the index whenever we feel it changed. However,
  we currently do not have any processes or definitions in place that
  would make us do that.
- The naming is unclear: what is the difference between «experimental»
  and «unstable»?
- It is unclear what these categories mean for day-to-day-work: am I not
  allowed to use non-stable styles? What would I use instead?
- The «stable» designation pretends that these styles won't change
  anymore, when in fact they are always up for discussion when we feel
  that the current definitions do not properly serve us anymore.

I propose instead that the styleguide is the documentation of the
current «state of the art» in our team, to be updated whenever
necessary.